### PR TITLE
Add more time precision options

### DIFF
--- a/docs/how_to.md
+++ b/docs/how_to.md
@@ -161,10 +161,32 @@ wdEdit.claim.add('Q4115189', 'P1476', { text: 'bulgroz', language: 'it' })
 // Example here with the unit 'minute' (Q7727)
 wdEdit.claim.add('Q4115189', 'P1106', { amount: 9001, unit: 'Q7727' })
 
-// Time property: only year, month, and day precision are supported yet (PR welcome!)
-wdEdit.claim.add('Q4115189', 'P569', '1802')
-wdEdit.claim.add('Q4115189', 'P569', '1802-02')
+// Time property
+// day, with implicit precision
 wdEdit.claim.add('Q4115189', 'P569', '1802-02-26')
+// day, with explicit precision
+// cf https://www.wikidata.org/wiki/Help:Dates#Precision
+wdEdit.claim.add('Q4115189', 'P569', { time: '1802-02-26', precision: 11 })
+// month
+wdEdit.claim.add('Q4115189', 'P569', '1802-02')
+wdEdit.claim.add('Q4115189', 'P569', { time: '1802-02', precision: 10 })
+// year
+wdEdit.claim.add('Q4115189', 'P569', '1802')
+wdEdit.claim.add('Q4115189', 'P569', { time: '1802', precision: 9 })
+// decade
+wdEdit.claim.add('Q4115189', 'P569', { time: '1800', precision: 8 })
+// century
+wdEdit.claim.add('Q4115189', 'P569', { time: '1800', precision: 7 })
+// millennium
+wdEdit.claim.add('Q4115189', 'P569', { time: '1000', precision: 6 })
+// ten thousand years
+wdEdit.claim.add('Q4115189', 'P569', { time: '-50000', precision: 5 })
+// hundred thousand years
+wdEdit.claim.add('Q4115189', 'P569', { time: '-100000', precision: 4 })
+// million years
+wdEdit.claim.add('Q4115189', 'P569', { time: '-1000000', precision: 3 })
+// billion years
+wdEdit.claim.add('Q4115189', 'P569', { time: '-13000000000', precision: 0 })
 
 // Quantity:
 // pass a single value for a count without a specific unit

--- a/lib/claim/builders.js
+++ b/lib/claim/builders.js
@@ -7,7 +7,7 @@ const { parseQuantity } = require('./quantity')
 const singleClaimBuilders = {
   string: str => `"${str}"`,
   entity: entityId => JSON.stringify(buildEntity(entityId)),
-  time: time => JSON.stringify(getTimeObject(time)),
+  time: (time, precision) => JSON.stringify(getTimeObject(time, precision)),
   // Property type specific builders
   monolingualtext: valueObj => JSON.stringify(valueObj),
   quantity: (quantity, unit = '1') => JSON.stringify(parseQuantity(quantity, unit))
@@ -21,7 +21,7 @@ const entityEditBuilders = {
   monolingualtext: (pid, valueObj) => {
     return statementBase(pid, 'monolingualtext', valueObj)
   },
-  time: (pid, time) => statementBase(pid, 'time', getTimeObject(time)),
+  time: (pid, time, precision) => statementBase(pid, 'time', getTimeObject(time, precision)),
   quantity: (pid, num) => statementBase(pid, 'quantity', parseQuantity(num))
 }
 

--- a/lib/claim/get_time_object.js
+++ b/lib/claim/get_time_object.js
@@ -1,37 +1,35 @@
 module.exports = (time, precision) => {
-  const precisionIndex = (precision === undefined) ? getPrecisionIndex(time) : timePrecisions[precision]
-  return timePrecisionObjectBuilders[precisionIndex](time)
+  if (precision == null) precision = getPrecision(time)
+  const timeStringBase = getTimeStringBase(time, precision)
+  return getPrecisionTimeObject(precision, timeStringBase)
 }
 
-// See https://www.wikidata.org/wiki/Help:Dates#Precision
-const timePrecisions = [
-  'billion', null, null, 'million', 'hundredsK', 'tensK',
-  'millenium', 'century', 'decade', 'year', 'month', 'day'
-]
+const getTimeStringBase = (time, precision) => {
+  if (precision === 11) return time
+  if (precision === 10) return time + '-00'
+  // From the year (9) to the billion years (0)
+  // See https://www.wikidata.org/wiki/Help:Dates#Precision
+  return time + '-00-00'
+}
 
-const compatPrecisionOffset = 9
-const getPrecisionIndex = time => timePrecisions[time.split('-').length - 1 + compatPrecisionOffset]
-
-const timePrecisionObjectBuilders = {
-  billion: years => getPrecisionTimeObject(0, `${years}-00-00${isoTimeRest}`),
-  million: years => getPrecisionTimeObject(3, `${years}-01-01${isoTimeRest}`),
-  hundredsK: years => getPrecisionTimeObject(4, `${years}-01-01${isoTimeRest}`),
-  tensK: years => getPrecisionTimeObject(5, `${years}-00-00${isoTimeRest}`),
-  millenium: year => getPrecisionTimeObject(6, `${year}-00-00${isoTimeRest}`),
-  century: year => getPrecisionTimeObject(7, `${year}-00-00${isoTimeRest}`),
-  decade: year => getPrecisionTimeObject(8, `${year}-00-00${isoTimeRest}`),
-  year: year => getPrecisionTimeObject(9, `${year}-00-00${isoTimeRest}`),
-  month: month => getPrecisionTimeObject(10, `${month}-00${isoTimeRest}`),
-  day: day => getPrecisionTimeObject(11, `${day}${isoTimeRest}`)
+// Guess precision from time string
+// 2018 (year): 9
+// 2018-03 (month): 10
+// 2018-03-03 (day): 11
+const getPrecision = time => {
+  const unsignedTime = time.replace(/^-/, '')
+  return unsignedTime.split('-').length + 8
 }
 
 const getPrecisionTimeObject = (precision, time) => {
   const sign = time[0]
+
   // The Wikidata API expects signed years
   // Default to a positive year sign
   if (sign !== '-' && sign !== '+') time = `+${time}`
+
   return {
-    time,
+    time: time + 'T00:00:00Z',
     timezone: 0,
     before: 0,
     after: 0,
@@ -39,5 +37,3 @@ const getPrecisionTimeObject = (precision, time) => {
     calendarmodel: 'http://www.wikidata.org/entity/Q1985727'
   }
 }
-
-const isoTimeRest = 'T00:00:00Z'

--- a/lib/claim/get_time_object.js
+++ b/lib/claim/get_time_object.js
@@ -1,13 +1,25 @@
-module.exports = time => {
-  const precision = getPrecisionIndex(time)
-  return timePrecisionObjectBuilders[precision](time)
+module.exports = (time, precision) => {
+  const precisionIndex = (precision === undefined) ? getPrecisionIndex(time) : timePrecisions[precision]
+  return timePrecisionObjectBuilders[precisionIndex](time)
 }
 
-const timePrecisions = [ 'year', 'month', 'day' ]
+// See https://www.wikidata.org/wiki/Help:Dates#Precision
+const timePrecisions = [
+  'billion', null, null, 'million', 'hundredsK', 'tensK',
+  'millenium', 'century', 'decade', 'year', 'month', 'day'
+]
 
-const getPrecisionIndex = time => timePrecisions[time.split('-').length - 1]
+const compatPrecisionOffset = 9
+const getPrecisionIndex = time => timePrecisions[time.split('-').length - 1 + compatPrecisionOffset]
 
 const timePrecisionObjectBuilders = {
+  billion: years => getPrecisionTimeObject(0, `${years}-00-00${isoTimeRest}`),
+  million: years => getPrecisionTimeObject(3, `${years}-01-01${isoTimeRest}`),
+  hundredsK: years => getPrecisionTimeObject(4, `${years}-01-01${isoTimeRest}`),
+  tensK: years => getPrecisionTimeObject(5, `${years}-00-00${isoTimeRest}`),
+  millenium: year => getPrecisionTimeObject(6, `${year}-00-00${isoTimeRest}`),
+  century: year => getPrecisionTimeObject(7, `${year}-00-00${isoTimeRest}`),
+  decade: year => getPrecisionTimeObject(8, `${year}-00-00${isoTimeRest}`),
   year: year => getPrecisionTimeObject(9, `${year}-00-00${isoTimeRest}`),
   month: month => getPrecisionTimeObject(10, `${month}-00${isoTimeRest}`),
   day: day => getPrecisionTimeObject(11, `${day}${isoTimeRest}`)
@@ -17,7 +29,7 @@ const getPrecisionTimeObject = (precision, time) => {
   const sign = time[0]
   // The Wikidata API expects signed years
   // Default to a positive year sign
-  if (sign !== '-' || sign !== '+') time = `+${time}`
+  if (sign !== '-' && sign !== '+') time = `+${time}`
   return {
     time,
     timezone: 0,

--- a/lib/claim/get_time_object.js
+++ b/lib/claim/get_time_object.js
@@ -1,4 +1,7 @@
+const _ = require('../utils')
+
 module.exports = (time, precision) => {
+  if (_.isPlainObject(time)) ({ time, precision } = time)
   if (precision == null) precision = getPrecision(time)
   const timeStringBase = getTimeStringBase(time, precision)
   return getPrecisionTimeObject(precision, timeStringBase)

--- a/lib/claim/quantity.js
+++ b/lib/claim/quantity.js
@@ -4,9 +4,7 @@ const unitPrefix = 'http://www.wikidata.org/entity/'
 
 module.exports = {
   parseQuantity: (amount, unit = '1') => {
-    if (_.isPlainObject(amount)) {
-      [ amount, unit ] = [ amount.amount, amount.unit ]
-    }
+    if (_.isPlainObject(amount)) ({ amount, unit } = amount)
     if (wdk.isItemId(unit)) unit = unitPrefix + unit
     if (_.isString(amount)) {
       if (!_.isStringNumber(amount)) throw new Error(`invalid string number: ${amount}`)

--- a/lib/datatype_tests.js
+++ b/lib/datatype_tests.js
@@ -8,11 +8,23 @@ module.exports = {
   // See https://www.mediawiki.org/wiki/Wikibase/DataModel#Dates_and_times
   // The positive years will be signed later
   time: time => {
+    if (_.isPlainObject(time)) {
+      const { precision } = time
+      time = time.time
+      if (typeof precision !== 'number' || precision < 0 || precision > 13) {
+        return false
+      }
+    }
+    const year = time.replace(/^-/, '').split('-')[0]
     // Parsing as an ISO String should not throw an Invalid time value error
-    try {
-      new Date(time).toISOString()
-    } catch (err) {
-      return false
+    // Only trying to parse 5-digit years or below, as higher years
+    // will fail, even when valid Wikidata dates
+    if (year.length <= 5) {
+      try {
+        new Date(time).toISOString()
+      } catch (err) {
+        return false
+      }
     }
     // Only precision up to the day is handled
     // and minimum 4 years numbers, that is always padded with zeros

--- a/test/claim/add.js
+++ b/test/claim/add.js
@@ -77,6 +77,15 @@ describe('claim add', function () {
     .catch(done)
   })
 
+  it('should add a time claim with precision', done => {
+    checkAndAddClaim(sandboxEntity, 'P569', { time: '2500000', precision: 4 })
+    .then(res => {
+      res.success.should.equal(1)
+      done()
+    })
+    .catch(done)
+  })
+
   it('should reject a claim with an invalid time', done => {
     checkAndAddClaim(sandboxEntity, 'P569', '1802-22-33')
     .catch(err => {

--- a/test/claim/time.js
+++ b/test/claim/time.js
@@ -18,12 +18,28 @@ describe('claim time', function () {
       'precision': 9,
       'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
     })
+    getTimeObject('-2018').should.deepEqual({
+      'time': '-2018-00-00T00:00:00Z',
+      'timezone': 0,
+      'before': 0,
+      'after': 0,
+      'precision': 9,
+      'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
+    })
     done()
   })
 
   it('should parse month without precision', function (done) {
     getTimeObject('2018-03').should.deepEqual({
       'time': '+2018-03-00T00:00:00Z',
+      'timezone': 0,
+      'before': 0,
+      'after': 0,
+      'precision': 10,
+      'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
+    })
+    getTimeObject('-2018-03').should.deepEqual({
+      'time': '-2018-03-00T00:00:00Z',
       'timezone': 0,
       'before': 0,
       'after': 0,
@@ -42,12 +58,28 @@ describe('claim time', function () {
       'precision': 11,
       'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
     })
+    getTimeObject('-2018-03-03').should.deepEqual({
+      'time': '-2018-03-03T00:00:00Z',
+      'timezone': 0,
+      'before': 0,
+      'after': 0,
+      'precision': 11,
+      'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
+    })
     done()
   })
 
   it('should parse year with precision', function (done) {
     getTimeObject('2018', 9).should.deepEqual({
       'time': '+2018-00-00T00:00:00Z',
+      'timezone': 0,
+      'before': 0,
+      'after': 0,
+      'precision': 9,
+      'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
+    })
+    getTimeObject('-2018', 9).should.deepEqual({
+      'time': '-2018-00-00T00:00:00Z',
       'timezone': 0,
       'before': 0,
       'after': 0,
@@ -66,12 +98,28 @@ describe('claim time', function () {
       'precision': 10,
       'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
     })
+    getTimeObject('-2018-03', 10).should.deepEqual({
+      'time': '-2018-03-00T00:00:00Z',
+      'timezone': 0,
+      'before': 0,
+      'after': 0,
+      'precision': 10,
+      'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
+    })
     done()
   })
 
   it('should parse day with precision', function (done) {
     getTimeObject('2018-03-03', 11).should.deepEqual({
       'time': '+2018-03-03T00:00:00Z',
+      'timezone': 0,
+      'before': 0,
+      'after': 0,
+      'precision': 11,
+      'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
+    })
+    getTimeObject('-2018-03-03', 11).should.deepEqual({
+      'time': '-2018-03-03T00:00:00Z',
       'timezone': 0,
       'before': 0,
       'after': 0,
@@ -90,12 +138,28 @@ describe('claim time', function () {
       'precision': 8,
       'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
     })
+    getTimeObject('-2010', 8).should.deepEqual({
+      'time': '-2010-00-00T00:00:00Z',
+      'timezone': 0,
+      'before': 0,
+      'after': 0,
+      'precision': 8,
+      'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
+    })
     done()
   })
 
   it('should parse century with precision', function (done) {
     getTimeObject('2100', 7).should.deepEqual({
       'time': '+2100-00-00T00:00:00Z',
+      'timezone': 0,
+      'before': 0,
+      'after': 0,
+      'precision': 7,
+      'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
+    })
+    getTimeObject('-2100', 7).should.deepEqual({
+      'time': '-2100-00-00T00:00:00Z',
       'timezone': 0,
       'before': 0,
       'after': 0,
@@ -124,6 +188,26 @@ describe('claim time', function () {
       'before': 0,
       'after': 0,
       'precision': 5,
+      'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
+    })
+    done()
+  })
+
+  it('should parse ten thousand years without precision and assume its years', function (done) {
+    getTimeObject('-10000').should.deepEqual({
+      'time': '-10000-00-00T00:00:00Z',
+      'timezone': 0,
+      'before': 0,
+      'after': 0,
+      'precision': 9,
+      'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
+    })
+    getTimeObject('10000').should.deepEqual({
+      'time': '+10000-00-00T00:00:00Z',
+      'timezone': 0,
+      'before': 0,
+      'after': 0,
+      'precision': 9,
       'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
     })
     done()

--- a/test/claim/time.js
+++ b/test/claim/time.js
@@ -1,17 +1,16 @@
-const should = require('should')
-const time = require('../../lib/claim/get_time_object')
+require('should')
+const getTimeObject = require('../../lib/claim/get_time_object')
 
 describe('claim time', function () {
   this.timeout(20 * 1000)
 
   it('should be a function', done => {
-    time.should.be.a.Function()
+    getTimeObject.should.be.a.Function()
     done()
   })
 
   it('should parse year without precision', function (done) {
-    const t = time('2018')
-    t.should.deepEqual({
+    getTimeObject('2018').should.deepEqual({
       'time': '+2018-00-00T00:00:00Z',
       'timezone': 0,
       'before': 0,
@@ -23,8 +22,7 @@ describe('claim time', function () {
   })
 
   it('should parse month without precision', function (done) {
-    const t = time('2018-03')
-    t.should.deepEqual({
+    getTimeObject('2018-03').should.deepEqual({
       'time': '+2018-03-00T00:00:00Z',
       'timezone': 0,
       'before': 0,
@@ -36,8 +34,7 @@ describe('claim time', function () {
   })
 
   it('should parse day without precision', function (done) {
-    const t = time('2018-03-03')
-    t.should.deepEqual({
+    getTimeObject('2018-03-03').should.deepEqual({
       'time': '+2018-03-03T00:00:00Z',
       'timezone': 0,
       'before': 0,
@@ -48,9 +45,8 @@ describe('claim time', function () {
     done()
   })
 
-  it('should parse year wit precision ', function (done) {
-    const t = time('2018', 9)
-    t.should.deepEqual({
+  it('should parse year with precision', function (done) {
+    getTimeObject('2018', 9).should.deepEqual({
       'time': '+2018-00-00T00:00:00Z',
       'timezone': 0,
       'before': 0,
@@ -62,8 +58,7 @@ describe('claim time', function () {
   })
 
   it('should parse month with precision', function (done) {
-    const t = time('2018-03', 10)
-    t.should.deepEqual({
+    getTimeObject('2018-03', 10).should.deepEqual({
       'time': '+2018-03-00T00:00:00Z',
       'timezone': 0,
       'before': 0,
@@ -75,8 +70,7 @@ describe('claim time', function () {
   })
 
   it('should parse day with precision', function (done) {
-    const t = time('2018-03-03', 11)
-    t.should.deepEqual({
+    getTimeObject('2018-03-03', 11).should.deepEqual({
       'time': '+2018-03-03T00:00:00Z',
       'timezone': 0,
       'before': 0,
@@ -88,8 +82,7 @@ describe('claim time', function () {
   })
 
   it('should parse decade with precision', function (done) {
-    const t = time('2010', 8)
-    t.should.deepEqual({
+    getTimeObject('2010', 8).should.deepEqual({
       'time': '+2010-00-00T00:00:00Z',
       'timezone': 0,
       'before': 0,
@@ -101,8 +94,7 @@ describe('claim time', function () {
   })
 
   it('should parse century with precision', function (done) {
-    const t = time('2100', 7)
-    t.should.deepEqual({
+    getTimeObject('2100', 7).should.deepEqual({
       'time': '+2100-00-00T00:00:00Z',
       'timezone': 0,
       'before': 0,
@@ -114,8 +106,7 @@ describe('claim time', function () {
   })
 
   it('should parse millenium with precision', function (done) {
-    const t = time('2000', 6)
-    t.should.deepEqual({
+    getTimeObject('2000', 6).should.deepEqual({
       'time': '+2000-00-00T00:00:00Z',
       'timezone': 0,
       'before': 0,
@@ -127,8 +118,7 @@ describe('claim time', function () {
   })
 
   it('should parse ten thousand years with precision', function (done) {
-    const t = time('-10000', 5)
-    t.should.deepEqual({
+    getTimeObject('-10000', 5).should.deepEqual({
       'time': '-10000-00-00T00:00:00Z',
       'timezone': 0,
       'before': 0,
@@ -140,9 +130,8 @@ describe('claim time', function () {
   })
 
   it('should parse hundred thousand years with precision', function (done) {
-    const t = time('-2500000', 4)
-    t.should.deepEqual({
-      'time': '-2500000-01-01T00:00:00Z',
+    getTimeObject('-2500000', 4).should.deepEqual({
+      'time': '-2500000-00-00T00:00:00Z',
       'timezone': 0,
       'before': 0,
       'after': 0,
@@ -153,9 +142,8 @@ describe('claim time', function () {
   })
 
   it('should parse million years with precision', function (done) {
-    const t = time('-13798000000', 3)
-    t.should.deepEqual({
-      'time': '-13798000000-01-01T00:00:00Z',
+    getTimeObject('-13798000000', 3).should.deepEqual({
+      'time': '-13798000000-00-00T00:00:00Z',
       'timezone': 0,
       'before': 0,
       'after': 0,
@@ -166,8 +154,7 @@ describe('claim time', function () {
   })
 
   it('should parse billion years with precision', function (done) {
-    const t = time('-5000000000', 0)
-    t.should.deepEqual({
+    getTimeObject('-5000000000', 0).should.deepEqual({
       'time': '-5000000000-00-00T00:00:00Z',
       'timezone': 0,
       'before': 0,

--- a/test/claim/time.js
+++ b/test/claim/time.js
@@ -1,0 +1,180 @@
+const should = require('should')
+const time = require('../../lib/claim/get_time_object')
+
+describe('claim time', function () {
+  this.timeout(20 * 1000)
+
+  it('should be a function', done => {
+    time.should.be.a.Function()
+    done()
+  })
+
+  it('should parse year without precision', function (done) {
+    const t = time('2018')
+    t.should.deepEqual({
+      'time': '+2018-00-00T00:00:00Z',
+      'timezone': 0,
+      'before': 0,
+      'after': 0,
+      'precision': 9,
+      'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
+    })
+    done()
+  })
+
+  it('should parse month without precision', function (done) {
+    const t = time('2018-03')
+    t.should.deepEqual({
+      'time': '+2018-03-00T00:00:00Z',
+      'timezone': 0,
+      'before': 0,
+      'after': 0,
+      'precision': 10,
+      'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
+    })
+    done()
+  })
+
+  it('should parse day without precision', function (done) {
+    const t = time('2018-03-03')
+    t.should.deepEqual({
+      'time': '+2018-03-03T00:00:00Z',
+      'timezone': 0,
+      'before': 0,
+      'after': 0,
+      'precision': 11,
+      'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
+    })
+    done()
+  })
+
+  it('should parse year wit precision ', function (done) {
+    const t = time('2018', 9)
+    t.should.deepEqual({
+      'time': '+2018-00-00T00:00:00Z',
+      'timezone': 0,
+      'before': 0,
+      'after': 0,
+      'precision': 9,
+      'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
+    })
+    done()
+  })
+
+  it('should parse month with precision', function (done) {
+    const t = time('2018-03', 10)
+    t.should.deepEqual({
+      'time': '+2018-03-00T00:00:00Z',
+      'timezone': 0,
+      'before': 0,
+      'after': 0,
+      'precision': 10,
+      'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
+    })
+    done()
+  })
+
+  it('should parse day with precision', function (done) {
+    const t = time('2018-03-03', 11)
+    t.should.deepEqual({
+      'time': '+2018-03-03T00:00:00Z',
+      'timezone': 0,
+      'before': 0,
+      'after': 0,
+      'precision': 11,
+      'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
+    })
+    done()
+  })
+
+  it('should parse decade with precision', function (done) {
+    const t = time('2010', 8)
+    t.should.deepEqual({
+      'time': '+2010-00-00T00:00:00Z',
+      'timezone': 0,
+      'before': 0,
+      'after': 0,
+      'precision': 8,
+      'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
+    })
+    done()
+  })
+
+  it('should parse century with precision', function (done) {
+    const t = time('2100', 7)
+    t.should.deepEqual({
+      'time': '+2100-00-00T00:00:00Z',
+      'timezone': 0,
+      'before': 0,
+      'after': 0,
+      'precision': 7,
+      'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
+    })
+    done()
+  })
+
+  it('should parse millenium with precision', function (done) {
+    const t = time('2000', 6)
+    t.should.deepEqual({
+      'time': '+2000-00-00T00:00:00Z',
+      'timezone': 0,
+      'before': 0,
+      'after': 0,
+      'precision': 6,
+      'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
+    })
+    done()
+  })
+
+  it('should parse ten thousand years with precision', function (done) {
+    const t = time('-10000', 5)
+    t.should.deepEqual({
+      'time': '-10000-00-00T00:00:00Z',
+      'timezone': 0,
+      'before': 0,
+      'after': 0,
+      'precision': 5,
+      'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
+    })
+    done()
+  })
+
+  it('should parse hundred thousand years with precision', function (done) {
+    const t = time('-2500000', 4)
+    t.should.deepEqual({
+      'time': '-2500000-01-01T00:00:00Z',
+      'timezone': 0,
+      'before': 0,
+      'after': 0,
+      'precision': 4,
+      'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
+    })
+    done()
+  })
+
+  it('should parse million years with precision', function (done) {
+    const t = time('-13798000000', 3)
+    t.should.deepEqual({
+      'time': '-13798000000-01-01T00:00:00Z',
+      'timezone': 0,
+      'before': 0,
+      'after': 0,
+      'precision': 3,
+      'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
+    })
+    done()
+  })
+
+  it('should parse billion years with precision', function (done) {
+    const t = time('-5000000000', 0)
+    t.should.deepEqual({
+      'time': '-5000000000-00-00T00:00:00Z',
+      'timezone': 0,
+      'before': 0,
+      'after': 0,
+      'precision': 0,
+      'calendarmodel': 'http://www.wikidata.org/entity/Q1985727'
+    })
+    done()
+  })
+})

--- a/test/qualifier/add.js
+++ b/test/qualifier/add.js
@@ -108,6 +108,18 @@ describe('qualifier add', function () {
     .catch(done)
   })
 
+  it('should add a time qualifier with precision', done => {
+    claimGuidPromise
+    .then(guid => {
+      return addQualifier(guid, 'P580', { time: '1802-02', precision: 10 })
+      .then(res => {
+        res.success.should.equal(1)
+        done()
+      })
+    })
+    .catch(done)
+  })
+
   it('should add a quantity qualifier', done => {
     claimGuidPromise
     .then(guid => {


### PR DESCRIPTION
Work in progress PR to add more precision options for times. Need tests and glue to make callers of get_time_object aware of the new precision field. Backwards compatibility is preserved.
Working at this at Torino ODD18.